### PR TITLE
Add Certificate Create and Delete Workflows

### DIFF
--- a/aap_setup.yaml
+++ b/aap_setup.yaml
@@ -651,11 +651,13 @@
               keyring_survey: "WorkflowKeyRing"
               sign_with_survey: "CERTAUTH"
               sign_label_survey: "Workflow CA"
+              cn_survey: "Workflow Cert"
             related:
               success_nodes:
                 - identifier: createExpiringCert
               failure_nodes:
                 - identifier: deleteCA
+
 # Create a certificate 30 days in the feature (within the 90 day default to trigger refresh)
           - identifier: "createExpiringCert"
             unified_job_template:
@@ -667,6 +669,7 @@
               keyring_survey: "WorkflowKeyRing"
               sign_with_survey: "CERTAUTH"
               sign_label_survey: "Workflow CA"
+              cn_survey: "Workflow Expiring Cert"
               expiry_date_survey: "{{ '%Y-%m-%d'| strftime((ansible_date_time.epoch|int) + (60*60*24*30)) }}"
             related:
               success_nodes:


### PR DESCRIPTION
Add workflow that creates a CA, site cert that has a long term expiration date and an expiring site cert (expiring 30 days from now). Can then use search and renew playbook on both certificates to see that the non-expiring certificate won't be renewed and the expiring certificate will be renewed. You can delete all resources created with the delete certificate workflow for cleanup. There are also branching paths (success and failure nodes) in both workflows to show what that looks like as an example for users.